### PR TITLE
fix highlighting ruby classes

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -129,7 +129,6 @@
 
 .entity.name.type.class.type {
   color: #CAE682;
-  background-color: #242424;
 }
 
 .variable.parameter {


### PR DESCRIPTION
The background-color made selections invisible on ruby clases

before:
![screen shot 2014-11-10 at 10 51 24 am](https://cloud.githubusercontent.com/assets/1312687/4979787/d831b67e-68f9-11e4-91f1-4f7d7874fae3.png)

after:
![screen shot 2014-11-05 at 2 10 26 pm](https://cloud.githubusercontent.com/assets/1312687/4925044/e5f678b0-6527-11e4-82c5-f602299347ef.png)
